### PR TITLE
handle invalid request error

### DIFF
--- a/gosyntect.go
+++ b/gosyntect.go
@@ -46,6 +46,8 @@ type Response struct {
 var (
 	// ErrInvalidTheme is returned when the Query.Theme is not a valid theme.
 	ErrInvalidTheme = errors.New("invalid theme")
+	// ErrInvalidRequest is returned when we get a 400 from syntect_server.
+	ErrInvalidRequest = errors.New("invalid request")
 )
 
 type response struct {
@@ -90,6 +92,10 @@ func (c *Client) Highlight(ctx context.Context, q *Query) (*Response, error) {
 		return nil, errors.Wrap(err, fmt.Sprintf("making request to %s", c.url("/")))
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusBadRequest {
+		return nil, ErrInvalidRequest
+	}
 
 	// Can only call ht.Span() after the request has been exected, so add our span tags in now.
 	ht.Span().SetTag("Filepath", q.Filepath)

--- a/gosyntect.go
+++ b/gosyntect.go
@@ -46,7 +46,7 @@ type Response struct {
 var (
 	// ErrInvalidTheme is returned when the Query.Theme is not a valid theme.
 	ErrInvalidTheme = errors.New("invalid theme")
-	// ErrInvalidRequest is returned when we get a 400 from syntect_server.
+	// ErrInvalidRequest is returned when the request is too large for syntect_server to handle (e.g. file is too large to highlight).
 	ErrRequestTooLarge = errors.New("request too large")
 )
 

--- a/gosyntect.go
+++ b/gosyntect.go
@@ -47,7 +47,7 @@ var (
 	// ErrInvalidTheme is returned when the Query.Theme is not a valid theme.
 	ErrInvalidTheme = errors.New("invalid theme")
 	// ErrInvalidRequest is returned when we get a 400 from syntect_server.
-	ErrInvalidRequest = errors.New("invalid request")
+	ErrRequestTooLarge = errors.New("request too large")
 )
 
 type response struct {


### PR DESCRIPTION
As discussed in https://github.com/sourcegraph/sourcegraph/issues/3421#issuecomment-484279369, we need to handle cases where we try to highlight files that are too large. This PR catches all 400s and returns them as an invalid request.