### PR TITLE
Adds support for CSS-based highlighting using the new syntect_server API

### DIFF
--- a/gosyntect.go
+++ b/gosyntect.go
@@ -26,6 +26,7 @@ type Query struct {
 	Filepath string `json:"filepath"`
 
 	// Theme is the color theme to use for highlighting.
+	// If CSS is true, theme is ignored.
 	//
 	// See https://github.com/sourcegraph/syntect_server#embedded-themes
 	Theme string `json:"theme"`
@@ -39,6 +40,7 @@ type Query struct {
 
 	// LineLengthLimit is the maximum length of line that will be highlighted if set.
 	// Defaults to no max if zero.
+	// If CSS is false, LineLengthLimit is ignored.
 	LineLengthLimit int `json:"line_length_limit,omitempty"`
 
 	// StabilizeTimeout, if non-zero, overrides the default syntect_server

--- a/gosyntect.go
+++ b/gosyntect.go
@@ -118,7 +118,7 @@ type Client struct {
 	syntectServer string
 }
 
-// sharedClient is a shared client aross all HighlightCSSTable requests
+// sharedClient is a shared client across all HighlightCSSTable requests
 // so connections to the server can be reused.
 var sharedClient = &http.Client{Transport: &nethttp.Transport{}}
 


### PR DESCRIPTION
Adds support for CSS-based highlighting using the new API added in sourcegraph/syntect_server#31

Depends on: sourcegraph/syntect_server#31
Relates to: sourcegraph/sourcegraph#19986

